### PR TITLE
Add sbt 2.x cross-build support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,30 +1,24 @@
 import sbtwelcome.*
 
 val scala2Version = "2.12.18"
-val scala3Version = "3.6.2"
-
-inThisBuild(
-  List(
-    organization := "com.github.reibitto",
-    homepage := Some(url("https://github.com/reibitto/sbt-welcome")),
-    licenses := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
-    developers := List(
-      Developer("reibitto", "reibitto", "reibitto@users.noreply.github.com", url("https://reibitto.github.io"))
-    ),
-    scalaVersion := scala2Version,
-    crossScalaVersions += scala3Version
-  )
-)
+val scala3Version = "3.8.4"
 
 lazy val root = (project in file(".")).settings(
   name := "sbt-welcome",
   organization := "com.github.reibitto",
+  homepage := Some(url("https://github.com/reibitto/sbt-welcome")),
+  licenses := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
+  developers := List(
+    Developer("reibitto", "reibitto", "reibitto@users.noreply.github.com", url("https://reibitto.github.io"))
+  ),
+  scalaVersion := scala3Version,
+  crossScalaVersions := Seq(scala2Version, scala3Version),
   sbtPlugin := true,
   libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test,
   pluginCrossBuild / sbtVersion := {
     scalaBinaryVersion.value match {
       case "2.12" => "1.10.7"
-      case _      => "2.0.0-M1"
+      case _      => "2.0.0"
     }
   },
   conflictWarning := {
@@ -38,7 +32,7 @@ lazy val root = (project in file(".")).settings(
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
 
-logo :=
+LocalRootProject / logo :=
   s"""
      |       ______ _____                   ______
      |__________  /___  /_   ___      _________  /__________________ ________
@@ -52,13 +46,11 @@ logo :=
      |
      |""".stripMargin
 
-usefulTasks := Seq(
+LocalRootProject / usefulTasks := Seq(
   UsefulTask("~compile", "Compile with file-watch enabled"),
   UsefulTask("test", "Run all tests"),
   UsefulTask("fmt", "Run scalafmt on the entire project"),
   UsefulTask("publishLocal", "Publish the sbt plugin locally so that you can consume it from a different project")
 )
 
-logoColor := scala.Console.MAGENTA
-
-ThisBuild / organization := "com.github.reibitto"
+LocalRootProject / logoColor := scala.Console.MAGENTA

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.12.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
-addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.4.0")
+addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.5.0")

--- a/src/main/scala-3/sbtwelcome/SbtCompat.scala
+++ b/src/main/scala-3/sbtwelcome/SbtCompat.scala
@@ -1,5 +1,3 @@
 package sbtwelcome
 
 object SbtCompat {}
-
-export sbt.given_Conversion_Scope_RichScope


### PR DESCRIPTION
Upgrades the plugin to cross-build against both sbt 1.x (Scala 2.12) and sbt 2.x (Scala 3), following the official sbt 2.x migration guide (https://www.scala-sbt.org/2.x/docs/en/changes/migrating-from-sbt-1.x.html).

### Changes

`build.sbt`

 - Bump scala3Version from 3.6.2 → 3.8.4 — sbt 2.0.0 is compiled with Scala 3.8.4 (TASTy 28.8), which is forward-incompatible with 3.6.2
 - Update pluginCrossBuild / sbtVersion target from 2.0.0-M1 → 2.0.0 (stable release)
 - Use explicit crossScalaVersions := Seq(scala2Version, scala3Version) instead of fragile +=
 - Scope logo, usefulTasks and logoColor under LocalRootProject — in sbt 2.x bare settings are injected into all subprojects, not just the root
 - Remove duplicate ThisBuild / organization (already declared in project settings)

`project/build.properties`

 - Bump sbt 1.10.7 → 1.12.12

`project/plugins.sbt`

 - Update sbt-welcome self-reference to 0.5.0

`src/main/scala-3/sbtwelcome/SbtCompat.scala`

 - Remove export sbt.given_Conversion_Scope_RichScope — this given no longer exists in sbt 2.x and caused a compilation failure

### Verification

`sbt "+compile"` and `sbt "+test"` pass cleanly for both Scala 2.12/sbt 1.x and Scala 3.8.4/sbt 2.x (6/6 tests).